### PR TITLE
Fixed image preview functionality

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -21,3 +21,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+yarn.lock

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -40,3 +40,10 @@
 img {
   max-width: 500px;
 }
+
+.img-preview {
+  margin:2%;
+  display:flex;
+  padding:0.5%;
+  background-color: #fff
+}

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -35,15 +35,41 @@ function App() {
     setBear(res[0]);
   }
 
+  return (
+    <div className="App">
+      <header className="App-header">
+        <p>
+          Enter a URL!
+        </p>
 
-  function viewResults() {
-    if(viewres){
-      return(
-        <>
+
+
+        <form onSubmit={(e) => { e.preventDefault(); sendLink()}}>
+          <input type="url" onChange={(e) => { e.preventDefault(); setUrl(e.target.value)}}></input>
+          <input type="submit"></input>
+        </form>
+        <ImagePreview url ={url} />
+        <ViewResults
+            viewres = {viewres}
+            bear = {bear}
+            blackbear={blackbear}
+            grizzlybear={grizzlybear}
+            teddybear={teddybear}
+        />
+      </header>
+    </div>
+  );
+}
+
+// Component to display the results when user input is send to the model.
+const ViewResults = ({viewres,bear,blackbear,grizzlybear,teddybear}) => {
+  if (!viewres) return null;
+  return (
+    <>
+    <h4>Results!</h4>
       <p>
         You are a {bear} bear!
       </p>
-      <img src={url}></img>
       <h6>
       Black Bear: {blackbear}
       </h6>
@@ -53,25 +79,21 @@ function App() {
       <h6>
       Teddy Bear: {teddybear}
       </h6>
-      </>
-    )
-    }
-  }
-
-  return (
-    <div className="App">
-      <header className="App-header">
-        <p>
-          Enter a URL!
-        </p>
-        <form onSubmit={(e) => { e.preventDefault(); sendLink()}}>
-          <input type="url" onChange={(e) => { e.preventDefault(); setUrl(e.target.value)}}></input>
-          <input type="submit"></input>
-        </form>
-        {viewResults()}
-      </header>
-    </div>
-  );
+    </>
+  )
 }
 
+// Component that returns the preview of the given image
+const ImagePreview = ({url}) => {
+  if (!url)
+    return null;
+
+  // renders an error gif when an invalid image link is pasted
+  const default_URL = "https://media0.giphy.com/media/eNdTUcTWKL7O0UvonE/giphy.gif"
+  return (
+    <div className = "img-preview" >
+      <img src = {url} onError = {(e)=>{e.target.src = default_URL }} height="150px" width="150px" />
+    </div>
+  )
+}
 export default App;


### PR DESCRIPTION
**Brief Description of Fix**
Broke down the image preview and results into two separate functional components of its own. For the image preview, every time an image url is pasted, an image preview of the pasted url is shown. In case of an invalid image url is pasted [this](https://media0.giphy.com/media/eNdTUcTWKL7O0UvonE/giphy.gif) is shown. 

Also added `yarn.lock` to gitignore.

**Linked Issue**  
Closes #1 

Screenshot of fixes:
![image](https://user-images.githubusercontent.com/51489449/97776857-c688e400-1b91-11eb-8b30-561ae0140ab8.png)
![image](https://user-images.githubusercontent.com/51489449/97776872-e02a2b80-1b91-11eb-9f74-4f786ce0fa9b.png)

